### PR TITLE
Replace depreciated Slider component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Store Image Banner not displaying images. Replaced depreciated Slider component with Slider Layout component
+
 ## [0.0.10] - 2021-01-27
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -16,16 +16,14 @@
     "vtex.store": "2.x",
     "vtex.flex-layout": "0.x",
     "vtex.rich-text": "0.x",
+    "vtex.slider-layout": "0.x",
     "vtex.store-graphql": "2.x",
-    "vtex.store-components": "3.x",
     "vtex.store-sitemap": "2.x",
     "vtex.styleguide": "9.x",
     "vtex.render-runtime": "8.x",
-    "vtex.css-handles": "0.x"
+    "vtex.css-handles": "1.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "billingOptions": {
     "termsURL": "https://compliance.vtex.com/gdpr/policies/vtex-privacy-policy",
     "support": {
@@ -33,9 +31,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "policies": [
     {

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@types/co-body": "^0.0.3",
     "@types/node": "12.x",
-    "@vtex/api": "6.37.1",
+    "@vtex/api": "6.40.0",
     "@vtex/tsconfig": "^0.5.6",
     "eslint": "^6.3.0",
     "eslint-config-vtex": "^11.0.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -215,10 +215,10 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@vtex/api@6.37.1":
-  version "6.37.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.1.tgz#d6ded4f4a98e10596729af7097cff18be43a0e54"
-  integrity sha512-24BaVHCIbkC84UWAlGPuTnUYIFngOpeRa4u/6KCJDnir5GXjoCWAkj4E7OoQ2uvBy/uvs9X2+DIkqtiz1x5bvw==
+"@vtex/api@6.40.0":
+  version "6.40.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.40.0.tgz#830c4aaaad75a1a8cf86ce898010e081a89053f8"
+  integrity sha512-VDdg9KVoNQ6KxH6cM0Tgh+VF7ELLrORqk5lRaie4akUZXW2tqECFLZAvRi9UE29CLstqCLBGQjqxbuT1aj/mgQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/StoreAddress.tsx
+++ b/react/StoreAddress.tsx
@@ -12,7 +12,7 @@ const CSS_HANDLES = [
 ] as const
 
 const StoreAddress: StorefrontFunctionComponent = () => {
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
   const store = useContext(StoreContext)
 
   if (!store) {

--- a/react/StoreAmenities.tsx
+++ b/react/StoreAmenities.tsx
@@ -12,7 +12,7 @@ const CSS_HANDLES = [
 ] as const
 
 const StoreAmenities: StorefrontFunctionComponent = () => {
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
   const store = useContext(StoreContext)
 
   if (!store) {

--- a/react/StoreContacts.tsx
+++ b/react/StoreContacts.tsx
@@ -11,7 +11,7 @@ const CSS_HANDLES = [
 ] as const
 
 const StoreContacts: StorefrontFunctionComponent = () => {
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
   const store = useContext(StoreContext)
 
   if (!store) {

--- a/react/StoreHours.tsx
+++ b/react/StoreHours.tsx
@@ -26,7 +26,7 @@ interface StoreHoursProps {
 }
 
 const StoreHours: StorefrontFunctionComponent<StoreHoursProps> = ({ intl }) => {
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
   const store = useContext(StoreContext)
 
   if (!store) {

--- a/react/StoreImageBanner.tsx
+++ b/react/StoreImageBanner.tsx
@@ -11,7 +11,7 @@ const sliderClasses = {
 }
 
 const StoreImageBanner: StorefrontFunctionComponent = () => {
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
   const store = useContext(StoreContext)
   const classes = useCustomClasses(() => sliderClasses)
 

--- a/react/StoreImageBanner.tsx
+++ b/react/StoreImageBanner.tsx
@@ -1,39 +1,42 @@
 import React, { useContext } from 'react'
 import { defineMessages } from 'react-intl'
-import { useCssHandles } from 'vtex.css-handles'
-import { Slider } from 'vtex.store-components'
+import { useCssHandles, useCustomClasses } from 'vtex.css-handles'
+import { SliderLayout } from 'vtex.slider-layout'
 
 import { StoreContext } from './contexts/StoreContext'
 
 const CSS_HANDLES = ['imageBannerContainer', 'imageBannerListItem'] as const
+const sliderClasses = {
+  slideChildrenContainer: 'ph8 mv8',
+}
 
 const StoreImageBanner: StorefrontFunctionComponent = () => {
   const handles = useCssHandles(CSS_HANDLES)
   const store = useContext(StoreContext)
+  const classes = useCustomClasses(() => sliderClasses)
 
   if (!store) {
     return null
   }
 
   const sliderSettings = {
-    className: 'ph8 mw8 mv8',
-    dots: true,
+    showNavigationArrows: 'desktopOnly',
+    showPaginationDots: 'desktopOnly',
     infinite: true,
-    slidesToScroll: 1,
-    slidesToShow: 1,
-    autoplay: true,
-    speed: 500,
+    itemsPerPage: { desktop: 1, tablet: 1, phone: 1 },
+    autoplay: { timeout: 4000, stopOnHover: false },
+    classes,
   }
 
   return (
-    <div className={`${handles.imageBannerContainer}`}>
-      <Slider sliderSettings={sliderSettings}>
+    <div className={`${handles.imageBannerContainer} mw8`}>
+      <SliderLayout {...sliderSettings}>
         {store.images.map((image, i) => (
-          <div className={`${handles.imageBannerListItem}`} key={i}>
+          <div className={`${handles.imageBannerListItem} `} key={i}>
             <img src={image.url} alt="Store" />
           </div>
         ))}
-      </Slider>
+      </SliderLayout>
     </div>
   )
 }

--- a/react/StoreLocations.tsx
+++ b/react/StoreLocations.tsx
@@ -44,7 +44,7 @@ const StoreLocations: StorefrontFunctionComponent<StoreLocationsProps> = ({
     undefined
   )
 
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
 
   const handleCenter = (lon: number, lat: number, zoomSize: number) => {
     setMapCoordinates([lon, lat])

--- a/react/StoreLogo.tsx
+++ b/react/StoreLogo.tsx
@@ -16,7 +16,7 @@ const StoreLogo: StorefrontFunctionComponent<StoreLogoProps> = ({
   width,
   height,
 }) => {
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
   const store = useContext(StoreContext)
 
   if (!store) {

--- a/react/StoreManager.tsx
+++ b/react/StoreManager.tsx
@@ -11,7 +11,7 @@ const CSS_HANDLES = [
 ] as const
 
 const StoreManager: StorefrontFunctionComponent = () => {
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
   const store = useContext(StoreContext)
 
   if (!store) {

--- a/react/StoreMap.tsx
+++ b/react/StoreMap.tsx
@@ -29,7 +29,7 @@ const StoreMap: StorefrontFunctionComponent<StoreMapProps> = ({
     ssr: false,
   })
 
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
   const store = useContext(StoreContext)
 
   if (!store || !googleMapsKeys?.logistics?.googleMapsKey) {

--- a/react/StoreTitle.tsx
+++ b/react/StoreTitle.tsx
@@ -7,7 +7,7 @@ import { StoreContext } from './contexts/StoreContext'
 const CSS_HANDLES = ['titleText'] as const
 
 const StoreTitle: StorefrontFunctionComponent = () => {
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
   const store = useContext(StoreContext)
 
   if (!store) {

--- a/react/components/Listing.tsx
+++ b/react/components/Listing.tsx
@@ -30,7 +30,7 @@ const Listing: StorefrontFunctionComponent<ListingProps> = ({
   items,
   onChangeCenter,
 }) => {
-  const handles = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
 
   const handleChangeCenter = (item: Store, zoom: number) => {
     const { latitude, longitude } = item.location

--- a/react/components/Pinpoints.tsx
+++ b/react/components/Pinpoints.tsx
@@ -43,7 +43,7 @@ const Pinpoints = withScriptjs(
       markerState: {},
     })
 
-    const handles = useCssHandles(CSS_HANDLES)
+    const { handles } = useCssHandles(CSS_HANDLES)
 
     const { navigate } = useRuntime()
 

--- a/react/package.json
+++ b/react/package.json
@@ -25,14 +25,14 @@
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.6.0",
     "typescript": "3.9.7",
-    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
-    "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
+    "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.16.0/public/@types/vtex.flex-layout",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime",
     "vtex.rich-text": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rich-text@0.12.0/public/@types/vtex.rich-text",
-    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.110.0/public/@types/vtex.store",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.138.1/public/@types/vtex.store-components",
-    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.136.9/public/@types/vtex.store-graphql",
-    "vtex.store-sitemap": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.7/public/@types/vtex.store-sitemap",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
+    "vtex.slider-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.slider-layout@0.17.0/public/@types/vtex.slider-layout",
+    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.112.1/public/@types/vtex.store",
+    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.138.0/public/@types/vtex.store-graphql",
+    "vtex.store-sitemap": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.8/public/@types/vtex.store-sitemap",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -11,7 +11,8 @@
     "react-dom": "^16.12.0",
     "react-google-maps": "^9.4.5",
     "react-helmet": "^6.1.0",
-    "react-intl": "^3.12.0"
+    "react-intl": "^3.12.0",
+    "@vtex/css-handles": "^1.0.0"
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.1.3",

--- a/react/typings/vtex.css-handles.d.ts
+++ b/react/typings/vtex.css-handles.d.ts
@@ -1,0 +1,4 @@
+declare module 'vtex.css-handles' {
+  export const useCssHandles: any
+  export const useCustomClasses: any
+}

--- a/react/typings/vtex.slider-layout.d.ts
+++ b/react/typings/vtex.slider-layout.d.ts
@@ -1,0 +1,3 @@
+declare module 'vtex.slider-layout' {
+  export const SliderLayout: any
+}

--- a/react/typings/vtex.store-components.d.ts
+++ b/react/typings/vtex.store-components.d.ts
@@ -1,3 +1,0 @@
-declare module 'vtex.store-components' {
-  export const Slider
-}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5130,41 +5130,41 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
-  version "0.4.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles":
+  version "1.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles#336b23ef3a9bcb2b809529ba736783acd405d081"
 
-"vtex.flex-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout":
-  version "0.15.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout#1b3e061cec4711dea3a0b98ce3d0434fdcca890b"
+"vtex.flex-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.16.0/public/@types/vtex.flex-layout":
+  version "0.16.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.16.0/public/@types/vtex.flex-layout#06e825f6709de8d4d86b74b1940ca28a8fd319c2"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime":
-  version "8.126.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime#f529e960313579c39a9748820885b995f9d6d3e6"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime":
+  version "8.126.11"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime#aceb734766093b56954ec19a074574b4c2c95242"
 
 "vtex.rich-text@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rich-text@0.12.0/public/@types/vtex.rich-text":
   version "0.12.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rich-text@0.12.0/public/@types/vtex.rich-text#56d0486b024aec40ccce96ee1affc03d0119d40f"
 
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.138.1/public/@types/vtex.store-components":
-  version "3.138.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.138.1/public/@types/vtex.store-components#853d25d0601a99b2a420b6200a099a727b1eac2b"
+"vtex.slider-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.slider-layout@0.17.0/public/@types/vtex.slider-layout":
+  version "0.17.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.slider-layout@0.17.0/public/@types/vtex.slider-layout#dc96a8323163958dc0d23668ac35a958186a442b"
 
-"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.136.9/public/@types/vtex.store-graphql":
-  version "2.136.9"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.136.9/public/@types/vtex.store-graphql#23cefbc32cfa03b02a053feb7c1a6e97cefa1c19"
+"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.138.0/public/@types/vtex.store-graphql":
+  version "2.138.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.138.0/public/@types/vtex.store-graphql#a802ff0193cfaf1d9bca8d2cf36134977ac1f40e"
 
-"vtex.store-sitemap@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.7/public/@types/vtex.store-sitemap":
-  version "2.13.7"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.7/public/@types/vtex.store-sitemap#50e0beff0fe826dbd99d20ba439568126a9c24e5"
+"vtex.store-sitemap@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.8/public/@types/vtex.store-sitemap":
+  version "2.13.8"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-sitemap@2.13.8/public/@types/vtex.store-sitemap#b5c9a6d29d74d8deaab9a5c4f95d909fd94cc325"
 
-"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.110.0/public/@types/vtex.store":
-  version "2.110.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.110.0/public/@types/vtex.store#b6472e42914bbeaf805b9acf9137fe9302feecb4"
+"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.112.1/public/@types/vtex.store":
+  version "2.112.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.112.1/public/@types/vtex.store#cc8241b2ab975c28f22f59c0f4173351e25c4974"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide":
-  version "9.134.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide#7210ed4908f4e6482d2499d71c4cfcc21e3dfd6a"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide":
+  version "9.135.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide#744a8674d69a56594de969da36b263f94c9de66f"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1506,6 +1506,11 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.1.tgz#5668c0bce55a91f2b9566b1d8a4c0a8dbbc79764"
   integrity sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ==
 
+"@vtex/css-handles@^1.0.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@vtex/css-handles/-/css-handles-1.1.3.tgz#30bd1010f2907443188738f74dd11d3b6b4ac624"
+  integrity sha512-DkqnzMf5jW6lQ1L8wYb9fnXyh0FqZym8qEokGYjeLUqBLBAiVK8XbI4U0ezFswWTOJ3iHZUkUjqPt5WodxR29w==
+
 "@vtex/test-tools@^3.3.2":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@vtex/test-tools/-/test-tools-3.3.2.tgz#b131653d85f381c82efea12a13d08fc9b1f65c85"


### PR DESCRIPTION
#### What problem is this solving?

Some images in the `StoreImageBanner` block are not being displayed.

[see here](https://arcaplanet.myvtex.com/negozi-per-animali/roma-v-m-furio-camillo) (Photo tab)

This PR replaces the depreciated store Slider component with the store Slider Layout component.
<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[workspace](https://sdb--arcaplanet.myvtex.com/negozi-per-animali/roma-v-g-marconi)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![Screenshot from 2021-03-05 13-38-32](https://user-images.githubusercontent.com/22715037/110170920-26013580-7db8-11eb-9054-8b6afcc191d0.png)
