### PR TITLE
Fix/store detail display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved store address and week days display
+
 ## [0.0.12] - 2021-03-08
 
 ### Fixed

--- a/node/utils/formatBusinessHours.ts
+++ b/node/utils/formatBusinessHours.ts
@@ -1,13 +1,13 @@
 import type { BusinessHours, Mktg } from '../typings/stores'
 
 const DAY = {
-  sunday: 0,
   monday: 1,
   tuesday: 2,
   wednesday: 3,
   thursday: 4,
   friday: 5,
   saturday: 6,
+  sunday: 0,
 } as const
 
 export const formatBusinessHours = (mktg: Mktg) => {

--- a/react/StoreAddress.tsx
+++ b/react/StoreAddress.tsx
@@ -26,9 +26,9 @@ const StoreAddress: StorefrontFunctionComponent = () => {
       <div className={`${handles.addressBlock} t-body`}>
         {street ? `${street} ` : ''}
         <br />
-        {city ? `${city}` : ''}
-        {state ? `, ${state}` : ''}
-        {postalCode ? `, ${postalCode}` : ''}
+        {postalCode ? `${postalCode}, ` : ''}
+        {city ? `${city}, ` : ''}
+        {state ? `${state}` : ''}
       </div>
       <div
         className={`${handles.addressDirectionsContainer} mh7 flex items-center justify-center`}


### PR DESCRIPTION
#### What problem is this solving?

Requesting updates to the store page layout:

- Change the start of week display from Sunday to Monday
- Store address display order

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://sdb--arcaplanet.myvtex.com/negozi-per-animali/milano-v-g-giusti)

#### Screenshots or example usage:

![Screenshot from 2021-03-12 08-08-00](https://user-images.githubusercontent.com/22715037/110958621-1dee4c00-830a-11eb-9fd5-11807bb07498.png)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

